### PR TITLE
Add "python manage.py" to handle commands as run and shell

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,7 +1,7 @@
 import os
 
 from flask import Flask
-from flask.ext.bootstrap import Bootstrap
+from flask_bootstrap import Bootstrap
 from app.admin import configure_admin
 from app.db import db
 

--- a/app/db.py
+++ b/app/db.py
@@ -1,4 +1,4 @@
 # coding: utf-8
 """This module exists to avoid circular imports when importing db object"""
-from flask.ext.sqlalchemy import SQLAlchemy
+from flask_sqlalchemy import SQLAlchemy
 db = SQLAlchemy()

--- a/config/development.py
+++ b/config/development.py
@@ -2,5 +2,7 @@ import os
 
 DEBUG = True
 SECRET_KEY = 'quality is free!'
+LOGGER_ENABLED = True
+SQLALCHEMY_TRACK_MODIFICATIONS = True
 SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(
     os.path.dirname(__file__), '../data-dev.sqlite3')

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import logging
+import click
+from app import create_app, models, views, admin
+from app.db import db
+
+app = create_app()
+
+if app.config.get("LOGGER_ENABLED"):
+    logging.basicConfig(
+        level=getattr(logging, app.config.get("LOGGER_LEVEL", "DEBUG")),
+        format=app.config.get(
+            "LOGGER_FORMAT",
+            '%(asctime)s %(name)-12s %(levelname)-8s %(message)s'),
+        datefmt=app.config.get("LOGGER_DATE_FORMAT", '%d.%m %H:%M:%S')
+    )
+
+
+@click.group()
+def core_cmd():
+    """ Core commands wrapper """
+    pass
+
+
+@core_cmd.command()
+@click.option('--ipython/--no-ipython', default=True)
+def shell(ipython):
+    """Runs a Python shell with QPD context"""
+    import code
+    import readline
+    import rlcompleter
+    banner_msg = (
+        "Welcome to QPD interactive shell\n"
+        "\tAuto imported: app, db, models, views, admin"
+    )
+    _vars = globals()
+    _vars.update(locals())
+    _vars.update(dict(app=app, db=db, models=models, views=views, admin=admin))
+    readline.set_completer(rlcompleter.Completer(_vars).complete)
+    readline.parse_and_bind("tab: complete")
+    try:
+        if ipython is True:
+            from IPython import start_ipython
+            from traitlets.config import Config
+            c = Config()
+            c.TerminalInteractiveShell.banner2 = banner_msg
+            start_ipython(argv=[], user_ns=_vars, config=c)
+        else:
+            raise ImportError
+    except ImportError:
+        shell = code.InteractiveConsole(_vars)
+        shell.interact(banner=banner_msg)
+
+
+@core_cmd.command()
+def check():
+    """Prints app status"""
+    from pprint import pprint
+    print("Extensions.")
+    pprint(app.extensions)
+    print("Modules.")
+    pprint(app.blueprints)
+    print("App.")
+    return app
+
+
+@core_cmd.command()
+def showconfig():
+    """Print all config variables"""
+    from pprint import pprint
+    print("Config.")
+    pprint(dict(app.config))
+
+
+@core_cmd.command()
+@click.option('--reloader/--no-reloader', default=True)
+@click.option('--debug/--no-debug', default=True)
+@click.option('--host', default='127.0.0.1')
+@click.option('--port', default=5000)
+def run(reloader, debug, host, port):
+    """Run the Flask development server i.e. app.run()"""
+    app.run(use_reloader=reloader, debug=debug, host=host, port=port)
+
+help_text = """
+    QPD Interactive shell!
+    """
+manager = click.CommandCollection(help=help_text)
+manager.add_source(core_cmd)
+
+if __name__ == '__main__':
+    with app.app_context():
+        manager()


### PR DESCRIPTION
``` bash
$ python manage.py
Usage: manage.py [OPTIONS] COMMAND [ARGS]...

      QPD Interactive shell!

Options:
  --help  Show this message and exit.

Commands:
  check       Prints app status
  run         Run the Flask development server i.e.
  shell       Runs a Python shell with QPD context
  showconfig  Print all config variables
```

to run the application

``` bash
$ python manage.py run --port=9000 --host=127.0.0.1 --debug --reloader
08.06 10:49:41 werkzeug     INFO      * Running on http://127.0.0.1:9000/ (Press CTRL+C to quit)
08.06 10:49:41 werkzeug     INFO      * Restarting with stat
08.06 10:49:41 werkzeug     WARNING   * Debugger is active!
08.06 10:49:41 werkzeug     INFO      * Debugger pin code: 121-731-875
```

to start the shell

``` bash
$ python manage.py shell
Python 2.7.11 (default, Mar 31 2016, 20:46:51) 
Welcome to QPD interactive shell
    Auto imported: app, db, models, views, admin
In [1]: app
Out[1]: <Flask 'app'>

In [2]: models.Category.query.all()
Out[2]: [<Category cli>]
```
